### PR TITLE
[ci test] Adding qemu for cross-architecture wheel builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
The pyo3/maturin action needs some additional tooling in the runner to build across multiple target architectures. I _think_ this will allow CI to run but I can't be sure.